### PR TITLE
Filter out domains you don't want included in stats

### DIFF
--- a/data.php
+++ b/data.php
@@ -1,5 +1,7 @@
 <?php
     $log = array();
+    //add domains that you don't want in stats to $filter =' ' seperated by commas
+    $filter = '127.0.0.1' 
     $ipv6 = file_exists("/etc/pihole/.useIPv6");
     $hosts = file_exists("/etc/hosts") ? file("/etc/hosts") : array();
 
@@ -169,13 +171,28 @@
         fclose($NGC4889);
 
         return $swallowed;
-
     }
+
     function readInLog() {
         global $log;
-        return count($log) > 1 ? $log :
+        $logData = count($log) > 1 ? $log :
             file("/var/log/pihole.log");
+        // Avoid localhost entries to appear in the statistics
+        return array_filter($logData, "avoidLocalhostEntries");
     }
+
+    function avoidLocalhostEntries($var) {
+        global $filter;
+        // Explode filters on comma
+        $filters = explode(',', $filter);
+        // Trim whitespace around filter sections
+        $filters = array_map('trim', $filters);
+        // Put back together pipe-separated
+        $filters_str = implode('|', $filters);
+        // Avoid matching any filter sections
+        return (preg_match('/(' . $filters_str . ')/', $var) == false);
+    }
+
     function getDnsQueries($log) {
         return array_filter($log, "findQueries");
     }


### PR DESCRIPTION
Fixes pi-hole/pi-hole#496 .

Changes proposed in this pull request:

- Add the ability to filter a list of domains from the stats.

@pi-hole/dashboard

Fixes issue pi-hole/pi-hole#496 by @xoniq.  Most code taken from @xoniq in original issue thread.  I move $filter to global vars at the top for ease of use.